### PR TITLE
Add debug and release folders to the build directory structure

### DIFF
--- a/bld.sh
+++ b/bld.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
-BUILD_DIR=build
+FLAVOR=debug
+
+opt=$1
+case $opt in
+  release) FLAVOR=release
+esac
+
+BUILD_DIR=build/$FLAVOR
 
 ninja_all() {
     for dir in $BUILD_DIR/*/ ; do
@@ -8,7 +15,7 @@ ninja_all() {
 }
 
 setup_and_ninja() {
-    ./setup.sh
+    ./setup.sh $FLAVOR
     ninja_all
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,21 @@
 #!/bin/sh
-BUILD_DIR=build
 
-cd $BUILD_DIR/bs
-ninja install
+# Limit install to release flavor.
+FLAVOR=release
 
-cd ../rit
-ninja install
+BUILD_DIR=build/$FLAVOR
+
+install_bs_and_rit() {
+    cd $BUILD_DIR/bs
+    ninja install
+
+    cd ../rit
+    ninja install
+}
+
+setup_and_ninja_and_install() {
+    ./bld.sh $FLAVOR
+    install_bs_and_rit
+}
+
+[ -d $BUILD_DIR ] && install_bs_and_rit || setup_and_ninja_and_install

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
+FLAVOR=debug
+
+opt=$1
+case $opt in
+  release) FLAVOR=release
+esac
+
 SRC_DIR=src
-MESON_BLD_DIR=build
+MESON_BLD_DIR=build/$FLAVOR
 
 for dir in $SRC_DIR/*/ ; do
     dir=${dir#$SRC_DIR/}
-    meson $MESON_BLD_DIR/$dir $SRC_DIR/$dir
+    meson --buildtype $FLAVOR $MESON_BLD_DIR/$dir $SRC_DIR/$dir
 done

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-BUILD_DIR=build
+
+# Limit tests to the debug flavor
+FLAVOR=debug
+
+BUILD_DIR=build/$FLAVOR
 
 ninja_test_all() {
     for dir in $BUILD_DIR/*/ ; do
@@ -8,7 +12,7 @@ ninja_test_all() {
 }
 
 setup_and_ninja_and_test() {
-    ./bld.sh
+    ./bld.sh $FLAVOR
     ninja_test_all
 }
 


### PR DESCRIPTION
Updated the scripts to make debug & release versions of the apps.  Turns out, Meson by default only builds unoptimized debug bits.  Since I’m adding perf logging hooks, I’d like to run it on optimized bits.