### PR TITLE
Logging for sorter performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 custom_bin/*
+logs/*

--- a/rit_bs.sh
+++ b/rit_bs.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Use the full ISO8601 format
+TIME=$(date -u +%FT%TZ)
+LOGDIR="logs/rit_bis_perftest_$TIME"
+
+[ -d $LOGDIR ] || mkdir $LOGDIR
+
+# Run rit and bs and log the output
+rit 1000 | bs > $LOGDIR/test_1000_out.log 2> $LOGDIR/test_1000_perf.log
+rit 10000 | bs > $LOGDIR/test_10000_out.log 2> $LOGDIR/test_10000_perf.log
+rit 100000 | bs > $LOGDIR/test_100000_out.log 2> $LOGDIR/test_100000_perf.log
+rit 1000000 | bs > $LOGDIR/test_1000000_out.log 2> $LOGDIR/test_1000000_perf.log

--- a/src/bs/bs.cpp
+++ b/src/bs/bs.cpp
@@ -1,8 +1,6 @@
 #include "bubble_sort.h"
 #include "cerr_perf_logger.h"
-#include <iostream>
 #include "sorter_logging_decorator.h"
-#include <vector>
 
 std::vector<int> readStdInForInts();
 void sort(std::vector<int>& inputToSort);

--- a/src/bs/bs.cpp
+++ b/src/bs/bs.cpp
@@ -1,10 +1,24 @@
 #include "bubble_sort.h"
+#include "cerr_perf_logger.h"
 #include <iostream>
+#include "sorter_logging_decorator.h"
 #include <vector>
+
+std::vector<int> readStdInForInts();
+void sort(std::vector<int>& inputToSort);
+void printToStdOut(const std::vector<int>& ints);
 
 int main()
 {
+    std::vector<int> inputToSort = readStdInForInts();
+    sort(inputToSort);
+    printToStdOut(inputToSort);
 
+    return 0;
+}
+
+std::vector<int> readStdInForInts()
+{
     std::vector<int> inputToSort;
 
     int lastInt;
@@ -13,14 +27,26 @@ int main()
         inputToSort.push_back(lastInt);
     }
 
-    bubble_sort sorter;
-    sorter.sort(inputToSort);
+    return inputToSort;
+}
 
-    for(int i : inputToSort)
+void sort(std::vector<int>& inputToSort)
+{
+    bubble_sort coreSorter;
+    cerr_perf_logger<int> logger;
+    sorter_logging_decorator<int, bubble_sort, cerr_perf_logger<int>> sorter(
+        std::move(coreSorter),
+        std::move(logger));
+
+    sorter.sort(inputToSort);
+}
+
+void printToStdOut(const std::vector<int>& ints)
+{
+    for(int i : ints)
     {
         std::cout << i << " ";
     }
-    std::cout << std::endl;
 
-    return 0;
+    std::cout << std::endl;
 }

--- a/src/bs/bubble_sort.h
+++ b/src/bs/bubble_sort.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
+#include "sorter.h"
 
-class bubble_sort
+class bubble_sort : public sorter<int>
 {
 public:
-  void sort(std::vector<int>& vec);
+  virtual void sort(std::vector<int>& vec) override;
 };

--- a/src/bs/cerr_perf_logger.h
+++ b/src/bs/cerr_perf_logger.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <iostream>
+#include "logger.h"
+
+template<typename T>
+class cerr_perf_logger : public logger<T>
+{
+public:
+    virtual ~cerr_perf_logger() { }
+    virtual void logStart(const std::vector<T>& vec) override;
+    virtual void logStop(const std::vector<T>& vec) override;
+};
+
+
+template<typename T>
+void cerr_perf_logger<T>::logStart(const std::vector<T>& vec)
+{
+    std::cerr << "Testing Start" << std::endl;
+}
+
+template<typename T>
+void cerr_perf_logger<T>::logStop(const std::vector<T>& vec)
+{
+    std::cerr << "Testing End" << std::endl;
+}

--- a/src/bs/cerr_perf_logger.h
+++ b/src/bs/cerr_perf_logger.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <chrono>
 #include <iostream>
 #include "logger.h"
+
 
 template<typename T>
 class cerr_perf_logger : public logger<T>
@@ -10,17 +12,32 @@ public:
     virtual ~cerr_perf_logger() { }
     virtual void logStart(const std::vector<T>& vec) override;
     virtual void logStop(const std::vector<T>& vec) override;
+
+private:
+    std::chrono::high_resolution_clock::time_point _startTime;
 };
 
 
 template<typename T>
 void cerr_perf_logger<T>::logStart(const std::vector<T>& vec)
 {
-    std::cerr << "Testing Start" << std::endl;
+    using namespace std::chrono;
+    _startTime = high_resolution_clock::now();
+    std::cerr << "Sort started."
+              << std::endl;
 }
 
 template<typename T>
 void cerr_perf_logger<T>::logStop(const std::vector<T>& vec)
 {
-    std::cerr << "Testing End" << std::endl;
+    using namespace std::chrono;
+
+    high_resolution_clock::time_point endTime = high_resolution_clock::now();
+    high_resolution_clock::duration highResDuration = endTime - _startTime;
+    duration<double, std::ratio<1, 1000>> elapsedTime = highResDuration;
+
+    std::cerr << "Sort ended. [ElapsedTime: "
+              << elapsedTime.count()
+              << " ms]"
+              << std::endl;
 }

--- a/src/bs/fakeLogger.h
+++ b/src/bs/fakeLogger.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "logger.h"
-#include "testState.h"
+#include "sorterLoggingDecoratorTestState.h"
 
 class fakeLogger : public logger<int>
 {
 public:
-    fakeLogger(testState& state)
+    fakeLogger(sorterLoggingDecoratorTestState& state)
         : _state(state)
     {
     }
@@ -15,14 +15,14 @@ public:
 
     virtual void logStart(const std::vector<int>& /*vec*/) override
     {
-        _state.functionsCalled.push_back(testState::logStart);
+        _state.functionsCalled.push_back(sorterLoggingDecoratorTestState::logStart);
     }
 
     virtual void logStop(const std::vector<int>& /*vec*/) override
     {
-        _state.functionsCalled.push_back(testState::logEnd);
+        _state.functionsCalled.push_back(sorterLoggingDecoratorTestState::logEnd);
     }
 
 private:
-    testState& _state;
+    sorterLoggingDecoratorTestState& _state;
 };

--- a/src/bs/fakeLogger.h
+++ b/src/bs/fakeLogger.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "logger.h"
+#include "testState.h"
+
+class fakeLogger : public logger<int>
+{
+public:
+    fakeLogger(testState& state)
+        : _state(state)
+    {
+    }
+
+    ~fakeLogger() { }
+
+    virtual void logStart(const std::vector<int>& /*vec*/) override
+    {
+        _state.functionsCalled.push_back(testState::logStart);
+    }
+
+    virtual void logStop(const std::vector<int>& /*vec*/) override
+    {
+        _state.functionsCalled.push_back(testState::logEnd);
+    }
+
+private:
+    testState& _state;
+};

--- a/src/bs/fakeSorter.h
+++ b/src/bs/fakeSorter.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "sorter.h"
-#include "testState.h"
+#include "sorterLoggingDecoratorTestState.h"
 
 class fakeSorter : public sorter<int>
 {
 public:
-    fakeSorter(testState& state)
+    fakeSorter(sorterLoggingDecoratorTestState& state)
         : _state(state)
     {
     }
@@ -15,9 +15,9 @@ public:
 
     virtual void sort(std::vector<int>& /*vec*/) override
     {
-        _state.functionsCalled.push_back(testState::sort);
+        _state.functionsCalled.push_back(sorterLoggingDecoratorTestState::sort);
     }
 
 private:
-    testState& _state;
+    sorterLoggingDecoratorTestState& _state;
 };

--- a/src/bs/fakeSorter.h
+++ b/src/bs/fakeSorter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "sorter.h"
+#include "testState.h"
+
+class fakeSorter : public sorter<int>
+{
+public:
+    fakeSorter(testState& state)
+        : _state(state)
+    {
+    }
+
+    ~fakeSorter() { }
+
+    virtual void sort(std::vector<int>& /*vec*/) override
+    {
+        _state.functionsCalled.push_back(testState::sort);
+    }
+
+private:
+    testState& _state;
+};

--- a/src/bs/logger.h
+++ b/src/bs/logger.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <vector>
+
+template<typename T>
+class logger
+{
+public:
+    virtual ~logger() { }
+    virtual void logStart(const std::vector<T>& vec) = 0;
+    virtual void logStop(const std::vector<T>& vec) = 0;
+};

--- a/src/bs/meson.build
+++ b/src/bs/meson.build
@@ -23,6 +23,11 @@ bubble_sort_tests = executable('bubble_sort_tests',
           link_with: bubble_sort_lib,
           dependencies: boost_utfw)
 
+sorter_logging_decorator_tests = executable('sorter_logging_decorator_tests',
+                                    sources: 'sorter_logging_decorator_tests.cpp',
+                                    include_directories: includes,
+                                    dependencies: boost_utfw)
+
 executable('bs',
           sources: bs_exe_sources,
           include_directories: includes,
@@ -30,3 +35,4 @@ executable('bs',
           install: true)
 
 test('Bubble Sort Unit Tests', bubble_sort_tests)
+test('Sorter Logging Decorator Unit Tests', sorter_logging_decorator_tests)

--- a/src/bs/pch/bs_pch.h
+++ b/src/bs/pch/bs_pch.h
@@ -1,2 +1,3 @@
+#include <chrono>
 #include <iostream>
 #include <vector>

--- a/src/bs/sorter.h
+++ b/src/bs/sorter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <vector>
+
+template<typename T>
+class sorter
+{
+public:
+    virtual ~sorter() { }
+    virtual void sort(std::vector<T>& vec) = 0;
+};

--- a/src/bs/sorterLoggingDecoratorTestState.h
+++ b/src/bs/sorterLoggingDecoratorTestState.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-struct testState
+struct sorterLoggingDecoratorTestState
 {
     enum functionCall
     {

--- a/src/bs/sorter_logging_decorator.h
+++ b/src/bs/sorter_logging_decorator.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "logger.h"
+#include "sorter.h"
+
+template<typename T, class TSorter, class TLogger>
+class sorter_logging_decorator : public sorter<T>
+{
+public:
+    sorter_logging_decorator(
+        TSorter&& wrappedSorter,
+        TLogger&& logger);
+    virtual void sort(std::vector<T>& vec) override;
+
+private:
+    TSorter _wrappedSorter;
+    TLogger _logger;
+};
+
+template<typename T, class TSorter, class TLogger>
+sorter_logging_decorator<T, TSorter, TLogger>::sorter_logging_decorator(
+    TSorter&& wrappedSorter,
+    TLogger&& logger)
+    : _wrappedSorter(wrappedSorter)
+    , _logger(logger)
+{
+}
+
+template<typename T, class TSorter, class TLogger>
+void sorter_logging_decorator<T, TSorter, TLogger>::sort(
+    std::vector<T>& vec)
+{
+    _logger.logStart(vec);
+    _wrappedSorter.sort(vec);
+    _logger.logStop(vec);
+}

--- a/src/bs/sorter_logging_decorator_tests.cpp
+++ b/src/bs/sorter_logging_decorator_tests.cpp
@@ -2,62 +2,10 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
+#include "fakeLogger.h"
+#include "fakeSorter.h"
 #include "sorter_logging_decorator.h"
-
-struct testState
-{
-    enum functionCall
-    {
-        sort,
-        logStart,
-        logEnd,
-    };
-
-    std::vector<functionCall> functionsCalled;
-};
-
-class fakeSorter : public sorter<int>
-{
-public:
-    fakeSorter(testState& state)
-        : _state(state)
-    {
-    }
-
-    ~fakeSorter() { }
-
-    virtual void sort(std::vector<int>& /*vec*/) override
-    {
-        _state.functionsCalled.push_back(testState::sort);
-    }
-
-private:
-    testState& _state;
-};
-
-class fakeLogger : public logger<int>
-{
-public:
-    fakeLogger(testState& state)
-        : _state(state)
-    {
-    }
-
-    ~fakeLogger() { }
-
-    virtual void logStart(const std::vector<int>& /*vec*/) override
-    {
-        _state.functionsCalled.push_back(testState::logStart);
-    }
-
-    virtual void logStop(const std::vector<int>& /*vec*/) override
-    {
-        _state.functionsCalled.push_back(testState::logEnd);
-    }
-
-private:
-    testState& _state;
-};
+#include "testState.h"
 
 std::vector<int> GetAnyVector()
 {

--- a/src/bs/sorter_logging_decorator_tests.cpp
+++ b/src/bs/sorter_logging_decorator_tests.cpp
@@ -5,7 +5,7 @@
 #include "fakeLogger.h"
 #include "fakeSorter.h"
 #include "sorter_logging_decorator.h"
-#include "testState.h"
+#include "sorterLoggingDecoratorTestState.h"
 
 std::vector<int> GetAnyVector()
 {
@@ -15,14 +15,14 @@ std::vector<int> GetAnyVector()
 BOOST_AUTO_TEST_CASE(Sort_AnyArray_LogStartWithArrayFollowedByLogStopWithArray)
 {
     // Arrange
-    testState state;
+    sorterLoggingDecoratorTestState state;
     sorter_logging_decorator<int, fakeSorter, fakeLogger> decorator(
         (fakeSorter(state)),
         (fakeLogger(state)));
-    std::vector<testState::functionCall> expectedCalls {
-        testState::logStart,
-        testState::sort,
-        testState::logEnd
+    std::vector<sorterLoggingDecoratorTestState::functionCall> expectedCalls {
+        sorterLoggingDecoratorTestState::logStart,
+        sorterLoggingDecoratorTestState::sort,
+        sorterLoggingDecoratorTestState::logEnd
     };
     auto anyVector = GetAnyVector();
 

--- a/src/bs/sorter_logging_decorator_tests.cpp
+++ b/src/bs/sorter_logging_decorator_tests.cpp
@@ -1,0 +1,86 @@
+#define BOOST_TEST_MODULE Sorter Logger Decorator Unit Tests
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "sorter_logging_decorator.h"
+
+struct testState
+{
+    enum functionCall
+    {
+        sort,
+        logStart,
+        logEnd,
+    };
+
+    std::vector<functionCall> functionsCalled;
+};
+
+class fakeSorter : public sorter<int>
+{
+public:
+    fakeSorter(testState& state)
+        : _state(state)
+    {
+    }
+
+    ~fakeSorter() { }
+
+    virtual void sort(std::vector<int>& /*vec*/) override
+    {
+        _state.functionsCalled.push_back(testState::sort);
+    }
+
+private:
+    testState& _state;
+};
+
+class fakeLogger : public logger<int>
+{
+public:
+    fakeLogger(testState& state)
+        : _state(state)
+    {
+    }
+
+    ~fakeLogger() { }
+
+    virtual void logStart(const std::vector<int>& /*vec*/) override
+    {
+        _state.functionsCalled.push_back(testState::logStart);
+    }
+
+    virtual void logStop(const std::vector<int>& /*vec*/) override
+    {
+        _state.functionsCalled.push_back(testState::logEnd);
+    }
+
+private:
+    testState& _state;
+};
+
+std::vector<int> GetAnyVector()
+{
+    return std::vector<int> { 3, 6, 1, -3 };
+}
+
+BOOST_AUTO_TEST_CASE(Sort_AnyArray_LogStartWithArrayFollowedByLogStopWithArray)
+{
+    // Arrange
+    testState state;
+    sorter_logging_decorator<int, fakeSorter, fakeLogger> decorator(
+        (fakeSorter(state)),
+        (fakeLogger(state)));
+    std::vector<testState::functionCall> expectedCalls {
+        testState::logStart,
+        testState::sort,
+        testState::logEnd
+    };
+    auto anyVector = GetAnyVector();
+
+    // Act
+    decorator.sort(anyVector);
+
+    // Assert
+    BOOST_TEST(expectedCalls == state.functionsCalled);
+}

--- a/src/bs/testState.h
+++ b/src/bs/testState.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <vector>
+
+struct testState
+{
+    enum functionCall
+    {
+        sort,
+        logStart,
+        logEnd,
+    };
+
+    std::vector<functionCall> functionsCalled;
+};


### PR DESCRIPTION
This change adds classes to modify sorters and add logging.  It incorporates a std::cerr logger and some scripts to do stress performance tests on the installed binaries.

The average run-time for rit 1000000 | bs is a little less than 450 seconds.